### PR TITLE
Fix tests

### DIFF
--- a/test/fixtures/test_create_project_with_missing_description.yml
+++ b/test/fixtures/test_create_project_with_missing_description.yml
@@ -5,7 +5,7 @@ http_interactions:
     uri: <URL>/manager
     body:
       encoding: US-ASCII
-      string: session.id=bf83e117-1705-4a13-80e0-435a6f41a92a&action=create&name=Azkaban%20Scheduler%20Test&description=description
+      string: session.id=bf83e117-1705-4a13-80e0-435a6f41a92a&action=create&name=Azkaban_Scheduler_Test&description=
     headers:
       Accept:
       - application/json
@@ -30,7 +30,7 @@ http_interactions:
       - CP="NOI DSP COR NID ADMa OPTa OUR NOR"
     body:
       encoding: US-ASCII
-      string: "{\"message\":\"Project names must start with a letter, followed by any number of letters, digits, '-' or '_'.\",\"status\":\"error\"}"
+      string: '{"message":"Description cannot be empty.","status":"error"}'
     http_version:
   recorded_at: Mon, 15 Sep 2014 17:55:55 GMT
 recorded_with: VCR 2.9.0

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -86,7 +86,7 @@ class SessionTest < Minitest::Test
     end
   end
 
-  def test_create_project_with_invalid_name
+  def test_create_project_with_missing_description
     project = AzkabanScheduler::Project.new('Azkaban_Scheduler_Test', "")
     assert_raises(AzkabanScheduler::ProjectDescriptionEmptyError) do
       VCR.use_cassette(__method__) do


### PR DESCRIPTION
There were previously two methods called test_create_project_with_invalid_name and one of the VCR fixtures was missing. This PR fixes that.
