### PR TITLE
Fix get_project_id when the project does not exist

### DIFF
--- a/lib/azkaban_scheduler/session.rb
+++ b/lib/azkaban_scheduler/session.rb
@@ -93,7 +93,7 @@ module AzkabanScheduler
 
     def list_flow_ids(project_name)
       result = fetch_project_flows(project_name)
-      result['flows'].map{ |flow| flow['flowId'] }
+      result.fetch('flows', []).map { |flow| flow['flowId'] }
     end
 
     def fetch_project_flows(project_name)
@@ -103,7 +103,7 @@ module AzkabanScheduler
         'project' => project_name,
       })
       response.error! unless response.kind_of?(Net::HTTPSuccess)
-      JSON.parse(response.body)
+      response.body.empty? ? {} : JSON.parse(response.body)
     end
 
     def fetch_flow_executions(project_name, flow_id, offset=0, limit=10)


### PR DESCRIPTION
The azkaban server returns an empty response body, but the status is 200. In that case we need to not parse the response body as JSON as that fails.
