### PR TITLE
Add the ability to specify HTTP options

### DIFF
--- a/lib/azkaban_scheduler/client.rb
+++ b/lib/azkaban_scheduler/client.rb
@@ -3,10 +3,17 @@ require 'json'
 
 module AzkabanScheduler
   class Client
-    def initialize(url)
+    attr_reader :http
+
+    def initialize(url, http_options = {})
       uri = URI(url)
+
       @http = Net::HTTP.new(uri.host, uri.port)
       @http.use_ssl = uri.scheme == 'https'
+
+      http_options.each do |key, value|
+        @http.public_send(:"#{key}=", value)
+      end
     end
 
     def get(path, params=nil, headers=nil)
@@ -31,7 +38,7 @@ module AzkabanScheduler
     def send_request(request, headers)
       request['Accept'] = 'application/json'
       headers.each { |name, value| request[name] = value } if headers
-      response = @http.request(request)
+      response = http.request(request)
       dump_response(response) if ENV['DUMP_AZKABAN_RESPONSES']
       response
     end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ClientTest < Minitest::Test
+  def test_http_options
+    client = AzkabanScheduler::Client.new('http://www.example.com', read_timeout: 5)
+
+    assert_kind_of Net::HTTP, client.http
+    assert_equal 5, client.http.read_timeout
+  end
+end


### PR DESCRIPTION
The default timeout of 60 seconds is pretty long when you're trying to script this thing. For our use-case the azkaban DNS only resolves if you're connected to the VPN, so we want to set a shorter timeout and print an error message indicating that you may not be connected.
