### PR TITLE
increase read timeout from 1 -> 3 mins

### DIFF
--- a/lib/azkaban_scheduler/client.rb
+++ b/lib/azkaban_scheduler/client.rb
@@ -9,7 +9,7 @@ module AzkabanScheduler
       uri = URI(url)
       @client_headers = client_headers
 
-      @http = Net::HTTP.new(uri.host, uri.port)
+      @http = Net::HTTP.new(uri.host, uri.port, read_timeout=180)
       @http.use_ssl = uri.scheme == 'https'
 
       http_options.each do |key, value|

--- a/lib/azkaban_scheduler/client.rb
+++ b/lib/azkaban_scheduler/client.rb
@@ -9,7 +9,8 @@ module AzkabanScheduler
       uri = URI(url)
       @client_headers = client_headers
 
-      @http = Net::HTTP.new(uri.host, uri.port, read_timeout=180)
+      @http = Net::HTTP.new(uri.host, uri.port)
+      @http.read_timeout = 180
       @http.use_ssl = uri.scheme == 'https'
 
       http_options.each do |key, value|

--- a/lib/azkaban_scheduler/version.rb
+++ b/lib/azkaban_scheduler/version.rb
@@ -1,3 +1,3 @@
 module AzkabanScheduler
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end


### PR DESCRIPTION
Increasing read timeout on requests because we post so many jobs that our deploys timeout. 

