### PR TITLE
Revert "increase read timeout from 1 -> 3 mins"

### DIFF
--- a/lib/azkaban_scheduler/client.rb
+++ b/lib/azkaban_scheduler/client.rb
@@ -10,7 +10,6 @@ module AzkabanScheduler
       @client_headers = client_headers
 
       @http = Net::HTTP.new(uri.host, uri.port)
-      @http.read_timeout = 180
       @http.use_ssl = uri.scheme == 'https'
 
       http_options.each do |key, value|

--- a/lib/azkaban_scheduler/version.rb
+++ b/lib/azkaban_scheduler/version.rb
@@ -1,3 +1,3 @@
 module AzkabanScheduler
-  VERSION = "0.0.5"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
Reverts Shopify/azkaban-scheduler-ruby#8 as it's an unnecessary change, because we can pass read_timeout to the client through `http_options`. 